### PR TITLE
Feature/integration of test coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 language: java
 jdk: openjdk11
+script:
+- ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+- ./mvnw prepare-package -B
+after_success:
+- bash <(curl -s https://codecov.io/bash)

--- a/README.adoc
+++ b/README.adoc
@@ -223,7 +223,15 @@ In order to execute the automated tests run the following command in the project
 
     mvnw test
 
-TODO: Describe how to generate test coverage report using JaCoCo Maven plugin as soon as it has been integrated.
+Project test coverage is reported by https://www.eclemma.org/jacoco/trunk/doc/maven.html[JaCoCo Maven plugin].
+
+To generate JaCoCo test coverage report it is necessary to run `prepare-package` maven build phase.
+
+    mvnw prepare-package
+
+After the phase has been completed JaCoCo test coverage report can be found in `target/site/jacoco/index.html`.
+
+Travis CI uploads JaCoCo test coverage reports to https://codecov.io[codecov.io]. Uploaded reports can be found here[https://codecov.io/gh/KnowledgeAssets/myskills-server].
 
 === Exploring the API
 

--- a/README.adoc
+++ b/README.adoc
@@ -231,7 +231,7 @@ To generate JaCoCo test coverage report it is necessary to run `prepare-package`
 
 After the phase has been completed JaCoCo test coverage report can be found in `target/site/jacoco/index.html`.
 
-Travis CI uploads JaCoCo test coverage reports to https://codecov.io[codecov.io]. Uploaded reports can be found here[https://codecov.io/gh/KnowledgeAssets/myskills-server].
+Travis CI uploads JaCoCo test coverage reports to https://codecov.io[codecov.io]. Uploaded reports can be found https://codecov.io/gh/KnowledgeAssets/myskills-server[here].
 
 === Exploring the API
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<java.version>11</java.version>
 		<springfox-swagger2.version>2.9.2</springfox-swagger2.version>
 		<neo4j.version>3.4.11</neo4j.version>
+		<jacoco.version>0.8.2</jacoco.version>
 	</properties>
 
 	<dependencies>
@@ -131,6 +132,33 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>@{argLine}</argLine>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>default-prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>default-report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
JaCoCo integrated.
JaCoCo reports are uploaded to codecov.io.
README.adoc updated to describe how JaCoCo report can be generated.
@svetivanova please take a look,