### PR TITLE
bugfix/update-of-user-skill-assignment-fails-due-to-security-expression

### DIFF
--- a/src/main/java/io/knowledgeassets/myskills/server/userskill/command/UserSkillCommandService.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/userskill/command/UserSkillCommandService.java
@@ -97,12 +97,9 @@ public class UserSkillCommandService {
 	 * This authentication.userAuthentication.Principal returns the UserIdentity object.
 	 * This makes sure that only owner or Admin users can change the userSkill record.
 	 *
-	 * @PreAuthorize("#userSkill.user.id.equals(authentication.userAuthentication.Principal.userId)")
-	 * @PreAuthorize("#userSkill.user.userName.equals(authentication.userAuthentication.Principal.userName)")
-	 * @PreAuthorize("#userSkill.user.userName == authentication.name")
 	 */
 	@Transactional
-	@PreAuthorize("#userSkill.user.userName.equals(authentication.userAuthentication.Principal.userName) || hasRole('ADMIN')")
+	@PreAuthorize("isPrincipalUserId(#userSkill.user.id) || hasRole('ADMIN')")
 	public UserSkill updateUserSkill(Integer currentLevel, Integer desiredLevel, Integer priority, UserSkill userSkill) {
 		userSkill.setCurrentLevel(currentLevel);
 		userSkill.setDesiredLevel(desiredLevel);
@@ -116,7 +113,7 @@ public class UserSkillCommandService {
 	 * @param userSkill
 	 */
 	@Transactional
-	@PreAuthorize("#userSkill.user.userName.equals(authentication.userAuthentication.Principal.userName) || hasRole('ADMIN')")
+	@PreAuthorize("isPrincipalUserId(#userSkill.user.id) || hasRole('ADMIN')")
 	public void deleteUserSkill(UserSkill userSkill) {
 		userSkillRepository.delete(userSkill);
 	}


### PR DESCRIPTION
#userSkill.user.userName.equals(authentication.userAuthentication.Principal.userName) is replaced with isPrincipalUserId(#userSkill.user.id) for user skill update / delete as it is done in the whole project.
@georgwittberger please take a look.

I decided not to remove Security annotations from the service layer just because the old Spring EL did not work anymore. I replaced not working expressions with io.knowledgeassets.myskills.server.security.MySkillsSecurityExpressionRoot#isPrincipalUserId as the meaning is the same in its essence - to check if an authenticated user is the one who performs some actions.