### PR TITLE
feature/provide-outbound-and-inbound-user-permissions

### DIFF
--- a/src/main/java/io/knowledgeassets/myskills/server/user/UserPermissionRepository.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/UserPermissionRepository.java
@@ -11,6 +11,8 @@ public interface UserPermissionRepository extends Neo4jRepository<UserPermission
 
 	Long deleteByOwnerId(String ownerId);
 
+	Iterable<UserPermission> findByAuthorizedUsersId(String authorizedUserId);
+
 	@Query("MATCH (:User {id:{ownerId}})-[:HAS_GRANTED]->(:UserPermission {scope:{scope}})-[:AUTHORIZES]->(authorizedUser:User {id:{authorizedUserId}}) " +
 			"RETURN COUNT(authorizedUser) > 0")
 	Boolean hasUserPermission(@Param("ownerId") String ownerId, @Param("authorizedUserId") String authorizedUserId,

--- a/src/main/java/io/knowledgeassets/myskills/server/user/command/UserPermissionCommandController.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/command/UserPermissionCommandController.java
@@ -31,8 +31,8 @@ public class UserPermissionCommandController {
 	}
 
 	@ApiOperation(
-			value = "Replace the list of granted user permissions",
-			notes = "Replace the entire list of granted user permissions for the user with the one in the request."
+			value = "Replace the list of user permissions granted by user.",
+			notes = "Replace the entire list of user permissions granted by user with a specified id."
 	)
 	@ApiResponses({
 			@ApiResponse(code = 200, message = "Successful execution"),
@@ -43,14 +43,14 @@ public class UserPermissionCommandController {
 			@ApiResponse(code = 500, message = "Error during execution")
 	})
 	@PreAuthorize("isPrincipalUserId(#userId)")
-	@PutMapping(path = "/users/{userId}/permissions",
+	@PutMapping(path = "/users/{userId}/outbound-permissions",
 			consumes = MediaType.APPLICATION_JSON_VALUE,
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	@CheckBindingResult
-	public List<UserPermissionResponse> replaceUserPermissions(@PathVariable("userId") String userId,
-															   @Valid @RequestBody List<UserPermissionRequest> userPermissionRequests,
-															   BindingResult bindingResult) {
-		return userPermissionCommandService.replaceUserPermissions(
+	public List<UserPermissionResponse> replaceOutboundUserPermissions(@PathVariable("userId") String userId,
+																	   @Valid @RequestBody List<UserPermissionRequest> userPermissionRequests,
+																	   BindingResult bindingResult) {
+		return userPermissionCommandService.replaceOutboundUserPermissions(
 				ReplaceUserPermissionListCommand.builder()
 						.ownerId(userId)
 						.userPermissions(userPermissionRequests.stream()

--- a/src/main/java/io/knowledgeassets/myskills/server/user/command/UserPermissionCommandService.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/command/UserPermissionCommandService.java
@@ -20,7 +20,7 @@ public class UserPermissionCommandService {
 	}
 
 	@Transactional
-	public Stream<UserPermission> replaceUserPermissions(ReplaceUserPermissionListCommand command) {
+	public Stream<UserPermission> replaceOutboundUserPermissions(ReplaceUserPermissionListCommand command) {
 		// Create mapping for each scope to the authorized users (merges potential duplicate scope entries).
 		Map<UserPermissionScope, Set<String>> scopeAuthorizedUsers = new HashMap<>();
 		command.getUserPermissions().forEach(userPermissionEntry -> {

--- a/src/main/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryController.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryController.java
@@ -36,10 +36,30 @@ public class UserPermissionQueryController {
 			@ApiResponse(code = 500, message = "Error during execution")
 	})
 	@PreAuthorize("isPrincipalUserId(#userId)")
-	@GetMapping(path = "/users/{userId}/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
-	public List<UserPermissionResponse> getUserPermissions(@PathVariable("userId") String userId) {
-		return userPermissionQueryService.getUserPermissionsByOwnerId(userId)
+	@GetMapping(path = "/users/{userId}/outbound-permissions", produces = MediaType.APPLICATION_JSON_VALUE)
+	public List<UserPermissionResponse> getOutboundUserPermissions(@PathVariable("userId") String userId) {
+		return userPermissionQueryService.getOutboundUserPermissionsByOwnerId(userId)
 				.map(UserPermissionResponse::of)
 				.collect(toList());
 	}
+
+	@ApiOperation(
+			value = "Get all user permissions granted to the user.",
+			notes = "Get all user permissions the given user has been granted by other users in the system."
+	)
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "Successful execution"),
+			@ApiResponse(code = 401, message = "Invalid authentication"),
+			@ApiResponse(code = 403, message = "Insufficient privileges to access resource, e.g. foreign user data"),
+			@ApiResponse(code = 404, message = "Resource not found"),
+			@ApiResponse(code = 500, message = "Error during execution")
+	})
+	@PreAuthorize("isPrincipalUserId(#userId)")
+	@GetMapping(path = "/users/{userId}/inbound-permissions", produces = MediaType.APPLICATION_JSON_VALUE)
+	public List<UserPermissionResponse> getInboundUserPermissions(@PathVariable("userId") String userId) {
+		return userPermissionQueryService.getInboundUserPermissionsByAuthorizedUserId(userId)
+				.map(UserPermissionResponse::of)
+				.collect(toList());
+	}
+
 }

--- a/src/main/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryService.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryService.java
@@ -19,7 +19,7 @@ public class UserPermissionQueryService {
 	}
 
 	@Transactional(readOnly = true)
-	public Stream<UserPermission> getUserPermissionsByOwnerId(String ownerId) {
+	public Stream<UserPermission> getOutboundUserPermissionsByOwnerId(String ownerId) {
 		return StreamSupport.stream(userPermissionRepository.findByOwnerId(ownerId).spliterator(), false);
 	}
 
@@ -33,4 +33,11 @@ public class UserPermissionQueryService {
 	public boolean hasUserPermission(String ownerId, String authorizedUserId, UserPermissionScope scope) {
 		return userPermissionRepository.hasUserPermission(ownerId, authorizedUserId, scope);
 	}
+
+	@Transactional(readOnly = true)
+	public Stream<UserPermission> getInboundUserPermissionsByAuthorizedUserId(String authorizedUserId) {
+		return StreamSupport.stream(userPermissionRepository.findByAuthorizedUsersId(authorizedUserId)
+				.spliterator(), false);
+	}
+
 }

--- a/src/test/java/io/knowledgeassets/myskills/server/user/UserPermissionRepositoryTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/user/UserPermissionRepositoryTests.java
@@ -1,0 +1,45 @@
+package io.knowledgeassets.myskills.server.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataNeo4jTest
+class UserPermissionRepositoryTests {
+
+	@Autowired
+	private UserPermissionRepository userPermissionRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("Finds user permissions granted to the user with a specified user id.")
+	void findsUserPermissionsGrantedToUserWithSpecifiedUserId() {
+		User owner = User.builder().id("123").userName("owner")
+				.firstName("owner").email("owner@gmail.com").build();
+		userRepository.save(owner);
+
+		User authorizedUser = User.builder().id("456").userName("authorizedUser")
+				.firstName("authorizedUser").email("authorizeduser@gmail.com").build();
+		userRepository.save(authorizedUser);
+
+		UserPermission userPermission = UserPermission.builder()
+				.owner(owner)
+				.authorizedUsers(Collections.singletonList(authorizedUser))
+				.scope(UserPermissionScope.READ_USER_SKILLS)
+				.id("ABC")
+				.build();
+		userPermissionRepository.save(userPermission);
+
+		Iterable<UserPermission> userPermissions = userPermissionRepository.findByAuthorizedUsersId("456");
+		assertThat(userPermissions).hasSize(1);
+		assertThat(userPermissions).containsExactlyInAnyOrder(userPermission);
+	}
+
+}

--- a/src/test/java/io/knowledgeassets/myskills/server/user/command/UserPermissionCommandControllerTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/user/command/UserPermissionCommandControllerTests.java
@@ -67,7 +67,7 @@ class UserPermissionCommandControllerTests extends AbstractControllerTests {
 				.build();
 
 		willThrow(new IllegalArgumentException("Unexpected data in command object!"))
-				.given(userPermissionCommandService).replaceUserPermissions(any());
+				.given(userPermissionCommandService).replaceOutboundUserPermissions(any());
 		willReturn(Stream.of(UserPermission.builder()
 				.scope(UserPermissionScope.READ_USER_SKILLS)
 				.owner(owner)
@@ -104,7 +104,7 @@ class UserPermissionCommandControllerTests extends AbstractControllerTests {
 								.build()
 				))
 				.build()))
-				.given(userPermissionCommandService).replaceUserPermissions(expectedCommand);
+				.given(userPermissionCommandService).replaceOutboundUserPermissions(expectedCommand);
 
 		String requestContent = "[{" +
 				"\"scope\":\"READ_USER_SKILLS\"," +
@@ -114,7 +114,7 @@ class UserPermissionCommandControllerTests extends AbstractControllerTests {
 				"]" +
 				"}]";
 
-		mockMvc.perform(put("/users/db87d46a-e4ca-451a-903b-e8533e0b924b/permissions")
+		mockMvc.perform(put("/users/db87d46a-e4ca-451a-903b-e8533e0b924b/outbound-permissions")
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestContent)
@@ -182,7 +182,7 @@ class UserPermissionCommandControllerTests extends AbstractControllerTests {
 				"]" +
 				"}]";
 
-		mockMvc.perform(put("/users/db87d46a-e4ca-451a-903b-e8533e0b924b/permissions")
+		mockMvc.perform(put("/users/db87d46a-e4ca-451a-903b-e8533e0b924b/outbound-permissions")
 				.accept(MediaType.APPLICATION_JSON)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestContent)

--- a/src/test/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryControllerTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryControllerTests.java
@@ -32,8 +32,8 @@ class UserPermissionQueryControllerTests extends AbstractControllerTests {
 	private MockMvc mockMvc;
 
 	@Test
-	@DisplayName("Tests getting all user permissions granted to other users.")
-	void testGettingAllUserPermissionsGrantedToOtherUsers() throws Exception {
+	@DisplayName("Tests getting all outbound user permissions granted to other users.")
+	void testGettingAllOutboundUserPermissionsGrantedToOtherUsers() throws Exception {
 		final User owner = User.builder()
 				.id("adac977c-8e0d-4e00-98a8-da7b44aa5dd6")
 				.userName("johndoe")
@@ -66,7 +66,7 @@ class UserPermissionQueryControllerTests extends AbstractControllerTests {
 				.languages(Collections.singletonList("English"))
 				.build();
 
-		given(userPermissionQueryService.getUserPermissionsByOwnerId("adac977c-8e0d-4e00-98a8-da7b44aa5dd6"))
+		given(userPermissionQueryService.getOutboundUserPermissionsByOwnerId("adac977c-8e0d-4e00-98a8-da7b44aa5dd6"))
 		.willReturn(Stream.of(
 				UserPermission.builder()
 					.owner(owner)
@@ -75,7 +75,7 @@ class UserPermissionQueryControllerTests extends AbstractControllerTests {
 					.id("4af0d371-364e-46c7-881b-e96c6385103e")
 				.build()
 		));
-		mockMvc.perform(get("/users/adac977c-8e0d-4e00-98a8-da7b44aa5dd6/permissions")
+		mockMvc.perform(get("/users/adac977c-8e0d-4e00-98a8-da7b44aa5dd6/outbound-permissions")
 				.accept(MediaType.APPLICATION_JSON)
 				.with(authentication(withUser(owner))))
 				.andExpect(status().isOk())
@@ -108,6 +108,118 @@ class UserPermissionQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[0].authorizedUsers[0].specializations").doesNotExist())
 				.andExpect(jsonPath("$[0].authorizedUsers[0].certificates").doesNotExist())
 				.andExpect(jsonPath("$[0].authorizedUsers[0].languages").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("Tests getting all inbound user permissions granted by other users.")
+	void testGettingAllInboundUserPermissionsGrantedByOtherUsers() throws Exception {
+		final User owner = User.builder()
+				.id("adac977c-8e0d-4e00-98a8-da7b44aa5dd6")
+				.userName("johndoe")
+				.firstName("John")
+				.lastName("Doe")
+				.email("john.doe@mail.com")
+				.coach(false)
+				.academicDegree("Diplom-Wirtschaftsinformatiker")
+				.positionProfile("Software Developer")
+				.summary("Developer")
+				.industrySectors(Arrays.asList("Automotive", "Telecommunication"))
+				.specializations(Arrays.asList("IT Consulting", "Software Integration"))
+				.certificates(Collections.singletonList("Java Certified Programmer"))
+				.languages(Collections.singletonList("Deutsch"))
+				.build();
+
+		final User tester = User.builder()
+				.id("bcbc938c-8e0d-4e00-98a8-da7b44aa5dd6")
+				.userName("marydoe")
+				.firstName("Mary")
+				.lastName("Doe")
+				.email("mary.doe@mail.com")
+				.coach(false)
+				.academicDegree("Diplom-Wirtschaftsinformatiker")
+				.positionProfile("Software Architect")
+				.summary("Architect")
+				.industrySectors(Arrays.asList("Automotive", "Telecommunication"))
+				.specializations(Arrays.asList("IT Consulting", "Software Integration"))
+				.certificates(Collections.singletonList("Scala Certified Programmer"))
+				.languages(Collections.singletonList("English"))
+				.build();
+
+		given(userPermissionQueryService.getInboundUserPermissionsByAuthorizedUserId("adac977c-8e0d-4e00-98a8-da7b44aa5dd6"))
+				.willReturn(Stream.of(
+						UserPermission.builder()
+								.owner(tester)
+								.scope(UserPermissionScope.READ_USER_SKILLS)
+								.authorizedUsers(Collections.singletonList(owner))
+								.id("4af0d371-364e-46c7-881b-e96c6385103e")
+								.build()
+				));
+		mockMvc.perform(get("/users/adac977c-8e0d-4e00-98a8-da7b44aa5dd6/inbound-permissions")
+				.accept(MediaType.APPLICATION_JSON)
+				.with(authentication(withUser(owner))))
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.length()", is(equalTo(1))))
+				.andExpect(jsonPath("$[0].owner.id", is(equalTo("bcbc938c-8e0d-4e00-98a8-da7b44aa5dd6"))))
+				.andExpect(jsonPath("$[0].owner.userName", is(equalTo("marydoe"))))
+				.andExpect(jsonPath("$[0].owner.firstName", is(equalTo("Mary"))))
+				.andExpect(jsonPath("$[0].owner.lastName", is(equalTo("Doe"))))
+				.andExpect(jsonPath("$[0].owner.email", is(equalTo("mary.doe@mail.com"))))
+				.andExpect(jsonPath("$[0].owner.coach", is(equalTo(false))))
+				.andExpect(jsonPath("$[0].owner.academicDegree").doesNotExist())
+				.andExpect(jsonPath("$[0].owner.positionProfile").doesNotExist())
+				.andExpect(jsonPath("$[0].owner.summary").doesNotExist())
+				.andExpect(jsonPath("$[0].owner.industrySectors").doesNotExist())
+				.andExpect(jsonPath("$[0].owner.specializations").doesNotExist())
+				.andExpect(jsonPath("$[0].owner.certificates").doesNotExist())
+				.andExpect(jsonPath("$[0].owner.languages").doesNotExist())
+				.andExpect(jsonPath("$[0].scope", is(equalTo("READ_USER_SKILLS"))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].id", is(equalTo("adac977c-8e0d-4e00-98a8-da7b44aa5dd6"))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].userName", is(equalTo("johndoe"))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].firstName", is(equalTo("John"))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].lastName", is(equalTo("Doe"))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].email", is(equalTo("john.doe@mail.com"))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].coach", is(equalTo(false))))
+				.andExpect(jsonPath("$[0].authorizedUsers[0].academicDegree").doesNotExist())
+				.andExpect(jsonPath("$[0].authorizedUsers[0].positionProfile").doesNotExist())
+				.andExpect(jsonPath("$[0].authorizedUsers[0].summary").doesNotExist())
+				.andExpect(jsonPath("$[0].authorizedUsers[0].industrySectors").doesNotExist())
+				.andExpect(jsonPath("$[0].authorizedUsers[0].specializations").doesNotExist())
+				.andExpect(jsonPath("$[0].authorizedUsers[0].certificates").doesNotExist())
+				.andExpect(jsonPath("$[0].authorizedUsers[0].languages").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("Tests if forbidden (403) status code is returned when a user requests inbound permissions of another user.")
+	void testIfNotAuthorizedStatusCodeIsReturnedWhenUserRequestsInboundPermissionsOfAnotherUser() throws Exception {
+		final User owner = User.builder()
+				.id("adac977c-8e0d-4e00-98a8-da7b44aa5dd6")
+				.userName("johndoe")
+				.firstName("John")
+				.lastName("Doe")
+				.email("john.doe@mail.com")
+				.coach(false)
+				.academicDegree("Diplom-Wirtschaftsinformatiker")
+				.positionProfile("Software Developer")
+				.summary("Developer")
+				.industrySectors(Arrays.asList("Automotive", "Telecommunication"))
+				.specializations(Arrays.asList("IT Consulting", "Software Integration"))
+				.certificates(Collections.singletonList("Java Certified Programmer"))
+				.languages(Collections.singletonList("Deutsch"))
+				.build();
+
+		mockMvc.perform(get("/users/bcbc938c-8e0d-4e00-98a8-da7b44aa5dd6/inbound-permissions")
+				.accept(MediaType.APPLICATION_JSON)
+				.with(authentication(withUser(owner))))
+				.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("Tests if unauthorized (401) status code is returned when an anonymous user requests inbound permissions of a user.")
+	void testIfUnauthorizedStatusCodeIsReturnedWhenAnonymousUserRequestsInboundPermissionsOfUser() throws Exception {
+		mockMvc.perform(get("/users/bcbc938c-8e0d-4e00-98a8-da7b44aa5dd6/inbound-permissions")
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isUnauthorized());
 	}
 
 }

--- a/src/test/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryServiceTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/user/query/UserPermissionQueryServiceTests.java
@@ -1,0 +1,66 @@
+package io.knowledgeassets.myskills.server.user.query;
+
+import io.knowledgeassets.myskills.server.user.User;
+import io.knowledgeassets.myskills.server.user.UserPermission;
+import io.knowledgeassets.myskills.server.user.UserPermissionRepository;
+import io.knowledgeassets.myskills.server.user.UserPermissionScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.BDDMockito.given;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class UserPermissionQueryServiceTests {
+
+	@Mock
+	private UserPermissionRepository userPermissionRepository;
+
+	private UserPermissionQueryService userPermissionQueryService;
+
+	@BeforeEach
+	void setUp() {
+		userPermissionQueryService = new UserPermissionQueryService(userPermissionRepository);
+	}
+
+	@Test
+	@DisplayName("fetches inbound user permissions which were granted to the authorized user.")
+	void fetchesInboundUserPermissionsByAuthorizedUserId() {
+
+		User owner = User.builder().id("123").userName("owner")
+				.firstName("owner").email("owner@gmail.com").build();
+
+		User authorizedUser = User.builder().id("456").userName("authorizedUser")
+				.firstName("authorizedUser").email("authorizeduser@gmail.com").build();
+
+		UserPermission userPermission = UserPermission.builder()
+				.owner(owner)
+				.authorizedUsers(Collections.singletonList(authorizedUser))
+				.scope(UserPermissionScope.READ_USER_SKILLS)
+				.id("ABC")
+				.build();
+
+		given(userPermissionRepository.findByAuthorizedUsersId("123")).willReturn(Collections.singletonList(userPermission));
+
+		Stream<UserPermission> userPermissions = userPermissionQueryService.getInboundUserPermissionsByAuthorizedUserId("123");
+
+		assertThat(userPermissions).isNotNull();
+		List<UserPermission> userPermissionsList = userPermissions.collect(toList());
+		assertThat(userPermissionsList).hasSize(1);
+		UserPermission result = userPermissionsList.get(0);
+		assertThat(result.getId()).isEqualTo("ABC");
+		assertThat(result.getScope()).isEqualTo(UserPermissionScope.READ_USER_SKILLS);
+		assertThat(result.getOwner()).isEqualTo(owner);
+		assertThat(result.getAuthorizedUsers()).isEqualTo(Collections.singletonList(authorizedUser));
+	}
+
+}


### PR DESCRIPTION
Paths to endpoints working with outbound user permissions were changed from /permissions to /outbound-permissions.
Controller, service and repository were adjusted to provide inbound user permissions with /inbound-permissions path.
Tests for the implemented feature.
@svetivanova could you please take a look?