### PR TITLE
feature/anonymous-user-profiles-for-specific-skill-requirements

### DIFF
--- a/src/main/java/io/knowledgeassets/myskills/server/exception/handler/LowLevelExceptionHandler.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/exception/handler/LowLevelExceptionHandler.java
@@ -12,9 +12,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
 
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 /**
  * This Handler is the last puzzle of all handlers(Minimum order).
@@ -42,6 +44,23 @@ public class LowLevelExceptionHandler implements IExceptionHandler {
 		doLog(ex, logMessage);
 
 		ResponseError responseError = new ResponseError(INTERNAL_SERVER_ERROR);
+		responseError.setMessage(ex.getLocalizedMessage());
+		return buildResponseEntity(ex, responseError);
+	}
+
+	/**
+	 * We catch all constraint violation exception that we want to send HttpStatus.BAD_REQUEST.
+	 * <p>
+	 *
+	 * @param ex
+	 * @return
+	 */
+	@ExceptionHandler({ConstraintViolationException.class})
+	protected ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex) {
+		String logMessage = String.format("{%s} Constraint Violation Exception! %s", BAD_REQUEST.value() + " " + BAD_REQUEST.getReasonPhrase(), ex.getLocalizedMessage());
+		doLog(ex, logMessage);
+
+		ResponseError responseError = new ResponseError(BAD_REQUEST);
 		responseError.setMessage(ex.getLocalizedMessage());
 		return buildResponseEntity(ex, responseError);
 	}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillRepository.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillRepository.java
@@ -1,0 +1,10 @@
+package io.knowledgeassets.myskills.server.search;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public interface AnonymousUserSkillRepository {
+
+	Stream<AnonymousUserSkillResult> findAnonymousUserSkillsBySkillLevels(List<UserSearchSkillCriterion> searchParams);
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillRepositoryImpl.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillRepositoryImpl.java
@@ -1,0 +1,58 @@
+package io.knowledgeassets.myskills.server.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.data.neo4j.transaction.SessionFactoryUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@Repository
+public class AnonymousUserSkillRepositoryImpl implements AnonymousUserSkillRepository {
+
+	private static final String QUERY = "MATCH (user:User)-[userSkill:RELATED_TO]-(skill:Skill) WHERE\n";
+	private static final String QUERY_PART = " userSkill.currentLevel >= %s AND skill.id = %s ";
+	private static final String QUERY_RESULT = " WITH userSkill, user, skill ORDER BY user.id, skill.id " +
+			" WITH collect(userSkill{ .*, skill: properties(skill)}) as userSkills, user, count(userSkill) as skillCount" +
+			" WHERE skillCount = $skillCount" +
+			" RETURN userSkills, user.referenceId as referenceId";
+
+	private final SessionFactory sessionFactory;
+
+	private final ObjectMapper objectMapper;
+
+	public AnonymousUserSkillRepositoryImpl(SessionFactory sessionFactory, ObjectMapper objectMapper) {
+		this.sessionFactory = requireNonNull(sessionFactory);
+		this.objectMapper = requireNonNull(objectMapper);
+	}
+
+	@Override
+	public Stream<AnonymousUserSkillResult> findAnonymousUserSkillsBySkillLevels(List<UserSearchSkillCriterion> searchParams) {
+		final Session session = SessionFactoryUtils.getSession(sessionFactory);
+		final StringBuilder query = new StringBuilder().append(QUERY);
+		final Map<String, Object> params = new HashMap<>();
+		for (int i = 0; i < searchParams.size(); i++) {
+			final UserSearchSkillCriterion criterion = searchParams.get(i);
+			final String levelParam = format("level%d", i);
+			final String skillParam = format("skill%d", i);
+			query.append(format(QUERY_PART, format("$%s", levelParam), format("$%s", skillParam)));
+			params.put(levelParam, criterion.getMinimumCurrentLevel());
+			params.put(skillParam, criterion.getSkillId());
+			if (i != searchParams.size() - 1) {
+				query.append(" OR ");
+			}
+		}
+		query.append(QUERY_RESULT);
+		params.put("skillCount", searchParams.size());
+		return StreamSupport.stream(session.query(query.toString(), params, true).spliterator(), false)
+				.map((Map<String, Object> m) -> objectMapper.convertValue(m, AnonymousUserSkillResult.class));
+	}
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillResult.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillResult.java
@@ -1,0 +1,25 @@
+package io.knowledgeassets.myskills.server.search;
+
+import io.knowledgeassets.myskills.server.userskill.UserSkill;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.neo4j.annotation.QueryResult;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@QueryResult
+public class AnonymousUserSkillResult {
+
+	/**
+	 * Anonymous reference to a user.
+	 */
+	private String referenceId;
+	private List<UserSkill> userSkills;
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/UserSearchSkillCriterion.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/UserSearchSkillCriterion.java
@@ -1,0 +1,22 @@
+package io.knowledgeassets.myskills.server.search;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * A criterion to search user by.
+ */
+@Data
+@Builder
+public class UserSearchSkillCriterion {
+
+	/**
+	 * An identifier of a skill.
+	 */
+	private String skillId;
+	/**
+	 * Minimum current level of a skill.
+	 */
+	private Integer minimumCurrentLevel;
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/query/AnonymousUserSkillResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/query/AnonymousUserSkillResponse.java
@@ -1,0 +1,23 @@
+package io.knowledgeassets.myskills.server.search.query;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Data
+@Builder
+@ApiModel(value = "User skill current levels with an anonymous user reference id.",
+	description = "User skill current levels with an anonymous user reference id. It is not possible to determine which user the skills belong to.")
+public class AnonymousUserSkillResponse {
+
+	@ApiModelProperty("User reference ID")
+	@NotEmpty
+	private String userReferenceId;
+
+	@ApiModelProperty("List of up-to-date user skill levels.")
+	private List<CurrentSkillLevelResponse> skills;
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/query/CurrentSkillLevelResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/query/CurrentSkillLevelResponse.java
@@ -1,0 +1,24 @@
+package io.knowledgeassets.myskills.server.search.query;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@ApiModel(value = "A pair of a skill name and current level of the skill.",
+		description = "A pair of a skill name and current level of the skill.")
+public class CurrentSkillLevelResponse {
+
+	@ApiModelProperty("Skill name")
+	@NotEmpty
+	private String skillName;
+	@ApiModelProperty("Current level of a skill")
+	@NotNull
+	private Integer currentLevel;
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/query/SearchController.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/query/SearchController.java
@@ -1,0 +1,78 @@
+package io.knowledgeassets.myskills.server.search.query;
+
+import io.knowledgeassets.myskills.server.search.AnonymousUserSkillResult;
+import io.knowledgeassets.myskills.server.search.UserSearchSkillCriterion;
+import io.knowledgeassets.myskills.server.userskill.UserSkill;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+@Api(tags = "Search", description = "API to search for entities.")
+@RestController
+@Validated
+@RequestMapping(path = "/search")
+public class SearchController {
+
+	private final SearchService searchService;
+
+	public SearchController(SearchService searchService) {
+		this.searchService = requireNonNull(searchService);
+	}
+
+	@ApiOperation(
+			value = "Get anonymous user profiles having some skills at least at specified level.",
+			notes = "Get anonymous user profiles having some skills at least at specified level."
+	)
+	@ApiResponses({
+			@ApiResponse(code = 200, message = "Successful execution"),
+			@ApiResponse(code = 401, message = "Invalid authentication"),
+			@ApiResponse(code = 403, message = "Insufficient privileges to access resource"),
+			@ApiResponse(code = 500, message = "Error during execution")
+	})
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping(path = "/users", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<List<AnonymousUserSkillResponse>> searchForAnonymousUserProfilesWithSkills(
+			@Valid @NotEmpty @RequestParam("params") List<@Pattern(regexp = "^.+\\+\\d+$") String> searchParameters) {
+		final List<UserSearchSkillCriterion> searchParams = extractUserSearchSkillCriterionList(searchParameters);
+		final List<AnonymousUserSkillResult> results = searchService.findAnonymousUserSkillsBySkillLevel(searchParams).collect(Collectors.toList());
+		return ResponseEntity.ok().body(results.stream().map((AnonymousUserSkillResult r) ->
+				AnonymousUserSkillResponse.builder()
+						.userReferenceId(r.getReferenceId())
+						.skills(r.getUserSkills().stream()
+								.map((UserSkill us) -> CurrentSkillLevelResponse.builder()
+										.currentLevel(us.getCurrentLevel())
+										.skillName(us.getSkill().getName())
+										.build())
+								.collect(Collectors.toList()))
+						.build()
+		).collect(Collectors.toList()));
+	}
+
+	private List<UserSearchSkillCriterion> extractUserSearchSkillCriterionList(List<String> searchParameters) {
+		return searchParameters.stream().map(s -> {
+			final String[] sp = s.split("\\+");
+			return UserSearchSkillCriterion.builder()
+					.skillId(sp[0])
+					.minimumCurrentLevel(Integer.valueOf(sp[1]))
+					.build();
+		}).collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/search/query/SearchService.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/search/query/SearchService.java
@@ -1,0 +1,31 @@
+package io.knowledgeassets.myskills.server.search.query;
+
+import io.knowledgeassets.myskills.server.search.AnonymousUserSkillRepository;
+import io.knowledgeassets.myskills.server.search.AnonymousUserSkillResult;
+import io.knowledgeassets.myskills.server.search.UserSearchSkillCriterion;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+@Service
+public class SearchService {
+
+	private final AnonymousUserSkillRepository anonymousUserSkillRepository;
+
+	public SearchService(AnonymousUserSkillRepository anonymousUserSkillRepository) {
+		this.anonymousUserSkillRepository = requireNonNull(anonymousUserSkillRepository);
+	}
+
+	@Transactional(readOnly = true)
+	public Stream<AnonymousUserSkillResult> findAnonymousUserSkillsBySkillLevel(List<UserSearchSkillCriterion> searchParams) {
+		if (searchParams == null || searchParams.isEmpty()) {
+			throw new IllegalArgumentException("There are no parameters to search by.");
+		}
+		return anonymousUserSkillRepository.findAnonymousUserSkillsBySkillLevels(searchParams);
+	}
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/user/User.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/User.java
@@ -19,6 +19,12 @@ public class User {
 	@Property(name = "id")
 	private String id;
 
+	/**
+	 * This field is forbidden to expose to any external system together with personal user data!!!
+	 */
+	@Property(name = "referenceId")
+	private String referenceId;
+
 	@Property(name = "userName")
 	@Index(unique = true)
 	private String userName;

--- a/src/main/java/io/knowledgeassets/myskills/server/user/command/UserCommandService.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/command/UserCommandService.java
@@ -39,6 +39,7 @@ public class UserCommandService {
 		});
 		return userRepository.save(User.builder()
 				.id(UUID.randomUUID().toString())
+				.referenceId(UUID.randomUUID().toString())
 				.userName(userName)
 				.firstName(firstName)
 				.lastName(lastName)

--- a/src/test/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillRepositoryTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/search/AnonymousUserSkillRepositoryTests.java
@@ -1,0 +1,181 @@
+package io.knowledgeassets.myskills.server.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.knowledgeassets.myskills.server.skill.Skill;
+import io.knowledgeassets.myskills.server.skill.SkillRepository;
+import io.knowledgeassets.myskills.server.user.User;
+import io.knowledgeassets.myskills.server.user.UserRepository;
+import io.knowledgeassets.myskills.server.userskill.UserSkill;
+import io.knowledgeassets.myskills.server.userskill.UserSkillRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.neo4j.ogm.session.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.stream.Collectors.toList;
+
+@DataNeo4jTest
+class AnonymousUserSkillRepositoryTests {
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private SkillRepository skillRepository;
+
+	@Autowired
+	private UserSkillRepository userSkillRepository;
+
+	private AnonymousUserSkillRepository anonymousUserSkillRepository;
+
+	@BeforeEach
+	void setUp() {
+
+		this.anonymousUserSkillRepository = new AnonymousUserSkillRepositoryImpl(sessionFactory, new ObjectMapper());
+
+		// Given
+		Skill angular = Skill.builder()
+				.id("A")
+				.name("Angular")
+				.description("JavaScript Framework")
+				.build();
+		angular = skillRepository.save(angular);
+		Skill springBoot = Skill.builder()
+				.id("B")
+				.name("Spring Boot")
+				.description("Java Application Framework")
+				.build();
+		springBoot = skillRepository.save(springBoot);
+		Skill springSecurity = Skill.builder()
+				.id("C")
+				.name("Spring Security")
+				.description("Java Security Framework")
+				.build();
+		springSecurity = skillRepository.save(springSecurity);
+
+		User tester = User.builder()
+				.id("1")
+				.referenceId("ref1")
+				.userName("tester")
+				.build();
+		tester = userRepository.save(tester);
+		User other = User.builder()
+				.id("2")
+				.referenceId("ref2")
+				.userName("other")
+				.build();
+		other = userRepository.save(other);
+
+		UserSkill testerAngular = UserSkill.builder()
+				.user(tester)
+				.skill(angular)
+				.currentLevel(1)
+				.desiredLevel(2)
+				.priority(3)
+				.build();
+		userSkillRepository.save(testerAngular);
+		UserSkill testerSpringBoot = UserSkill.builder()
+				.user(tester)
+				.skill(springBoot)
+				.currentLevel(2)
+				.desiredLevel(3)
+				.priority(4)
+				.build();
+		userSkillRepository.save(testerSpringBoot);
+		userSkillRepository.save(UserSkill.builder()
+				.user(other)
+				.skill(angular)
+				.currentLevel(1)
+				.desiredLevel(2)
+				.priority(3)
+				.build());
+		userSkillRepository.save(UserSkill.builder()
+				.user(other)
+				.skill(springSecurity)
+				.currentLevel(2)
+				.desiredLevel(3)
+				.priority(4)
+				.build());
+		userSkillRepository.save(UserSkill.builder()
+				.user(other)
+				.skill(springBoot)
+				.currentLevel(1)
+				.desiredLevel(2)
+				.priority(3)
+				.build());
+	}
+
+	@Test
+	@DisplayName("Tests if anonymous user skills are fetched by one parameter")
+	void testGettingAnonymousUserSkillsByOneParameter() {
+		Stream<AnonymousUserSkillResult> result = anonymousUserSkillRepository.findAnonymousUserSkillsBySkillLevels(Collections.singletonList(
+				UserSearchSkillCriterion.builder()
+						.skillId("B")
+						.minimumCurrentLevel(2)
+						.build()
+		));
+		assertThat(result).isNotNull();
+		List<AnonymousUserSkillResult> anonymousUserSkillResults = result.collect(toList());
+		assertThat(anonymousUserSkillResults).hasSize(1);
+		final AnonymousUserSkillResult res = anonymousUserSkillResults.get(0);
+		assertThat(res).isNotNull();
+		assertThat(res.getReferenceId()).isEqualTo("ref1");
+		final List<UserSkill> userSkills = anonymousUserSkillResults.get(0).getUserSkills();
+		assertThat(userSkills).hasSize(1);
+		final UserSkill userSkill = userSkills.get(0);
+		assertThat(userSkill).isNotNull();
+		assertThat(userSkill.getCurrentLevel()).isEqualTo(2);
+		final Skill skill = userSkill.getSkill();
+		assertThat(skill).isNotNull();
+		assertThat(skill.getName()).isEqualTo("Spring Boot");
+	}
+
+	@Test
+	@DisplayName("Tests if anonymous user skills are fetched by two parameters")
+	void testGettingAnonymousUserSkillsByTwoParameters() {
+		Stream<AnonymousUserSkillResult> result = anonymousUserSkillRepository.findAnonymousUserSkillsBySkillLevels(Arrays.asList(
+				UserSearchSkillCriterion.builder()
+						.skillId("B")
+						.minimumCurrentLevel(2)
+						.build(),
+				UserSearchSkillCriterion.builder()
+						.skillId("A")
+						.minimumCurrentLevel(1)
+						.build()
+		));
+		assertThat(result).isNotNull();
+		List<AnonymousUserSkillResult> anonymousUserSkillResults = result.collect(toList());
+		assertThat(anonymousUserSkillResults).hasSize(1);
+		final AnonymousUserSkillResult res = anonymousUserSkillResults.get(0);
+		assertThat(res).isNotNull();
+		assertThat(res.getReferenceId()).isEqualTo("ref1");
+		final List<UserSkill> userSkills = anonymousUserSkillResults.get(0).getUserSkills();
+		assertThat(userSkills).hasSize(2);
+		UserSkill userSkill = userSkills.get(0);
+		assertThat(userSkill).isNotNull();
+		assertThat(userSkill.getCurrentLevel()).isEqualTo(1);
+		Skill skill = userSkill.getSkill();
+		assertThat(skill).isNotNull();
+		assertThat(skill.getId()).isEqualTo("A");
+		assertThat(skill.getName()).isEqualTo("Angular");
+		userSkill = userSkills.get(1);
+		assertThat(userSkill).isNotNull();
+		assertThat(userSkill.getCurrentLevel()).isEqualTo(2);
+		skill = userSkill.getSkill();
+		assertThat(skill).isNotNull();
+		assertThat(skill.getId()).isEqualTo("B");
+		assertThat(skill.getName()).isEqualTo("Spring Boot");
+	}
+
+}

--- a/src/test/java/io/knowledgeassets/myskills/server/search/query/SearchControllerTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/search/query/SearchControllerTests.java
@@ -1,0 +1,135 @@
+package io.knowledgeassets.myskills.server.search.query;
+
+import io.knowledgeassets.myskills.server.common.AbstractControllerTests;
+import io.knowledgeassets.myskills.server.search.AnonymousUserSkillResult;
+import io.knowledgeassets.myskills.server.search.UserSearchSkillCriterion;
+import io.knowledgeassets.myskills.server.skill.Skill;
+import io.knowledgeassets.myskills.server.user.User;
+import io.knowledgeassets.myskills.server.userskill.UserSkill;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static io.knowledgeassets.myskills.server.common.JwtAuthenticationFactory.withUser;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SearchController.class)
+class SearchControllerTests extends AbstractControllerTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private SearchService searchService;
+
+	@Test
+	@DisplayName("Tests if BAD_REQUEST status code is returned when wrong search parameters are passed.")
+	void testIfBadRequestStatusCodeIsReturnedWhenWrongSearchParametersArePassed() throws Exception {
+		final User owner = User.builder()
+				.id("1f37fb2a-b4d0-4119-9113-4677beb20ae2")
+				.userName("tester")
+				.build();
+		mockMvc.perform(get("/search/users")
+				.param("params", "A2", "B1")
+				.with(authentication(withUser(owner))))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("Tests if BAD_REQUEST status code is returned when getting anonymous user skills with no parameters to filter by.")
+	void testIfBadRequestStatusCodeIsReturnedWhenThereAreNoParameterToFilterUserSkillsBy() throws Exception {
+		final User owner = User.builder()
+				.id("1f37fb2a-b4d0-4119-9113-4677beb20ae2")
+				.userName("tester")
+				.build();
+		mockMvc.perform(get("/search/users")
+				.with(authentication(withUser(owner))))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("Tests if BAD_REQUEST status code is returned when getting anonymous user skills with empty parameter list to filter by.")
+	void testIfBadRequestStatusCodeIsReturnedWhenThereAreEmptyParameterListToFilterUserSkillsBy() throws Exception {
+		final User owner = User.builder()
+				.id("1f37fb2a-b4d0-4119-9113-4677beb20ae2")
+				.userName("tester")
+				.build();
+		mockMvc.perform(get("/search/users")
+				.param("params", "")
+				.with(authentication(withUser(owner))))
+				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("Tests if UNAUTHORIZED status code is returned when a user sending a request is unknown.")
+	void testIfUnauthorizedStatusCodeIsReturnedWhenUserIsUnknown() throws Exception {
+		mockMvc.perform(get("/search/users"))
+				.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("Test if anonymous user skills are successfully retrieved.")
+	void testIfAnonymousUserSkillsAreSuccessfullyRetrieved() throws Exception {
+
+		given(searchService.findAnonymousUserSkillsBySkillLevel(Arrays.asList(UserSearchSkillCriterion.builder()
+						.skillId("B")
+						.minimumCurrentLevel(2)
+						.build(),
+				UserSearchSkillCriterion.builder()
+						.skillId("A")
+						.minimumCurrentLevel(1)
+						.build()
+				))
+		).willReturn(Stream.of(AnonymousUserSkillResult.builder()
+						.referenceId("ref1")
+						.userSkills(Arrays.asList(
+								UserSkill.builder()
+										.currentLevel(1)
+										.skill(Skill.builder()
+												.name("Angular")
+												.build())
+										.build(),
+								UserSkill.builder()
+										.currentLevel(2)
+										.skill(Skill.builder()
+												.name("Spring Boot")
+												.build())
+										.build()
+								)
+						)
+						.build()
+				)
+		);
+
+		final User owner = User.builder()
+				.id("1f37fb2a-b4d0-4119-9113-4677beb20ae2")
+				.userName("tester")
+				.build();
+		mockMvc.perform(get("/search/users")
+				.param("params", "B+2", "A+1")
+				.with(authentication(withUser(owner))))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.length()", is(equalTo(1))))
+				.andExpect(jsonPath("$[0].userReferenceId", is(equalTo("ref1"))))
+				.andExpect(jsonPath("$[0].skills.length()", is(equalTo(2))))
+				.andExpect(jsonPath("$[0].skills[0].skillName", is(equalTo("Angular"))))
+				.andExpect(jsonPath("$[0].skills[0].currentLevel", is(equalTo(1))))
+				.andExpect(jsonPath("$[0].skills[1].skillName", is(equalTo("Spring Boot"))))
+				.andExpect(jsonPath("$[0].skills[1].currentLevel", is(equalTo(2))));
+
+	}
+
+
+}

--- a/src/test/java/io/knowledgeassets/myskills/server/search/query/SearchServiceTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/search/query/SearchServiceTests.java
@@ -39,10 +39,15 @@ class SearchServiceTests {
 	@DisplayName("Tests if anonymous user skills are fetched.")
 	void testGettingAnonymousSkills() {
 
-		given(anonymousUserSkillRepository.findAnonymousUserSkillsBySkillLevels(Collections.singletonList(UserSearchSkillCriterion.builder()
-				.skillId("B")
-				.minimumCurrentLevel(2)
-				.build()))).willReturn(Stream.of(AnonymousUserSkillResult.builder()
+		given(anonymousUserSkillRepository.findAnonymousUserSkillsBySkillLevels(Arrays.asList(UserSearchSkillCriterion.builder()
+						.skillId("B")
+						.minimumCurrentLevel(2)
+						.build(),
+				UserSearchSkillCriterion.builder()
+						.skillId("A")
+						.minimumCurrentLevel(1)
+						.build()
+		))).willReturn(Stream.of(AnonymousUserSkillResult.builder()
 						.referenceId("ref1")
 						.userSkills(Arrays.asList(
 								UserSkill.builder()
@@ -64,10 +69,14 @@ class SearchServiceTests {
 		);
 
 		Stream<AnonymousUserSkillResult> result = searchService.findAnonymousUserSkillsBySkillLevel(
-				Collections.singletonList(UserSearchSkillCriterion.builder()
-						.skillId("B")
-						.minimumCurrentLevel(2)
-						.build())
+				Arrays.asList(UserSearchSkillCriterion.builder()
+								.skillId("B")
+								.minimumCurrentLevel(2)
+								.build(),
+						UserSearchSkillCriterion.builder()
+								.skillId("A")
+								.minimumCurrentLevel(1)
+								.build())
 		);
 
 		List<AnonymousUserSkillResult> res = result.collect(toList());

--- a/src/test/java/io/knowledgeassets/myskills/server/search/query/SearchServiceTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/search/query/SearchServiceTests.java
@@ -1,0 +1,94 @@
+package io.knowledgeassets.myskills.server.search.query;
+
+import io.knowledgeassets.myskills.server.search.AnonymousUserSkillRepository;
+import io.knowledgeassets.myskills.server.search.AnonymousUserSkillResult;
+import io.knowledgeassets.myskills.server.search.UserSearchSkillCriterion;
+import io.knowledgeassets.myskills.server.skill.Skill;
+import io.knowledgeassets.myskills.server.userskill.UserSkill;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static java.util.stream.Collectors.toList;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTests {
+
+	@Mock
+	private AnonymousUserSkillRepository anonymousUserSkillRepository;
+
+	private SearchService searchService;
+
+	@BeforeEach
+	void setUp() {
+		this.searchService = new SearchService(anonymousUserSkillRepository);
+	}
+
+	@Test
+	@DisplayName("Tests if anonymous user skills are fetched.")
+	void testGettingAnonymousSkills() {
+
+		given(anonymousUserSkillRepository.findAnonymousUserSkillsBySkillLevels(Collections.singletonList(UserSearchSkillCriterion.builder()
+				.skillId("B")
+				.minimumCurrentLevel(2)
+				.build()))).willReturn(Stream.of(AnonymousUserSkillResult.builder()
+						.referenceId("ref1")
+						.userSkills(Arrays.asList(
+								UserSkill.builder()
+										.currentLevel(1)
+										.skill(Skill.builder()
+												.name("Angular")
+												.build())
+										.build(),
+								UserSkill.builder()
+										.currentLevel(2)
+										.skill(Skill.builder()
+												.name("Spring Boot")
+												.build())
+										.build()
+								)
+						)
+						.build()
+				)
+		);
+
+		Stream<AnonymousUserSkillResult> result = searchService.findAnonymousUserSkillsBySkillLevel(
+				Collections.singletonList(UserSearchSkillCriterion.builder()
+						.skillId("B")
+						.minimumCurrentLevel(2)
+						.build())
+		);
+
+		List<AnonymousUserSkillResult> res = result.collect(toList());
+		assertThat(res).isNotNull();
+		assertThat(res).hasSize(1);
+		AnonymousUserSkillResult anonymousUserSkillResult = res.get(0);
+		assertThat(anonymousUserSkillResult.getReferenceId()).isEqualTo("ref1");
+		List<UserSkill> userSkills = anonymousUserSkillResult.getUserSkills();
+		assertThat(userSkills).hasSize(2);
+		final UserSkill firstUserSkill = userSkills.get(0);
+		assertThat(firstUserSkill.getCurrentLevel()).isEqualTo(1);
+		assertThat(firstUserSkill.getSkill().getName()).isEqualTo("Angular");
+		final UserSkill secondUserSkill = userSkills.get(1);
+		assertThat(secondUserSkill.getCurrentLevel()).isEqualTo(2);
+		assertThat(secondUserSkill.getSkill().getName()).isEqualTo("Spring Boot");
+	}
+
+	@Test
+	@DisplayName("Tests if an exception is thrown when there are no parameters to search by")
+	void testIfExceptionIsThrownWhenThereAreNoParametersToSearchBy() {
+		assertThrows(IllegalArgumentException.class, () -> searchService.findAnonymousUserSkillsBySkillLevel(Collections.emptyList()));
+	}
+
+}


### PR DESCRIPTION
API to search anonymous user skills by skill levels (available to all authenticated users).

(Controller, Service and Repository layers). Tests for implemented functionality.
The query to fetch anonymous user skills is built manually due to dynamic nature of the request (arbitrary number of search criteria).
org.neo4j.ogm.session.SessionFactory is used to communicate with the database.

@svetivanova could you please take a look?